### PR TITLE
feat: ruff lint + format pre-commit hook

### DIFF
--- a/templates/hooks/pre-commit-ruff.zsh
+++ b/templates/hooks/pre-commit-ruff.zsh
@@ -1,0 +1,68 @@
+#!/bin/zsh
+# Ruff lint + format check on staged Python files, scoped to repos that
+# opt into ruff. Catches BOTH classes a CI ruff step enforces:
+#   - `ruff check`        -- lint rules
+#   - `ruff format --check` -- formatting
+# CI runs these as TWO SEPARATE steps, so a clean `ruff check` does NOT
+# imply a clean `ruff format`. Skipping the format check locally is how a
+# format-only failure slips through to CI (burned 2026-06-02).
+#
+# Scoping: only runs when the repo opts into ruff — a `[tool.ruff]` table
+# in pyproject.toml at the git root, or a ruff.toml / .ruff.toml. Without
+# that signal we skip, so this never fires in repos that don't use ruff.
+#
+# Binary resolution: prefer a project-local .venv/bin/ruff (pinned
+# version), then `ruff` on PATH, then `uvx ruff` (matches uv-based CI).
+# Falls back to warn+skip when none resolve. `--force-exclude` makes ruff
+# honour the repo's own exclude config even though we pass explicit paths.
+# Author: https://github.com/fredericrous
+ERROR_SIGN=$'  \e[38;5;160m✗\e[0m'
+VALID_SIGN=$'  \e[38;5;112m✓\e[0m'
+WARNING_SIGN=$'  \e[38;5;208m!\e[0m'
+
+staged=(${(f)"$(git diff --diff-filter=d --cached --name-only)"})
+(( ${#staged} == 0 )) && exit 0
+files=(${(f)"$(printf '%s\n' $staged | grep -E '\.pyi?$')"})
+(( ${#files} == 0 )) && exit 0
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# --- decide whether this repo opts into ruff -------------------------
+# (N) null-glob: unmatched patterns vanish instead of erroring (zsh NOMATCH).
+has_config=0
+config_matches=("$ROOT"/ruff.toml(N.) "$ROOT"/.ruff.toml(N.))
+(( ${#config_matches} > 0 )) && has_config=1
+if (( ! has_config )) && [[ -f "$ROOT/pyproject.toml" ]]; then
+    grep -q '^\[tool\.ruff' "$ROOT/pyproject.toml" && has_config=1
+fi
+(( ! has_config )) && exit 0
+
+# --- resolve a ruff binary -------------------------------------------
+if [[ -x "$ROOT/.venv/bin/ruff" ]]; then
+    RUFF=("$ROOT/.venv/bin/ruff")
+elif type ruff > /dev/null 2>&1; then
+    RUFF=(ruff)
+elif type uvx > /dev/null 2>&1; then
+    RUFF=(uvx ruff)
+else
+    printf "$WARNING_SIGN ruff config found but no ruff/uvx binary. Install ruff or uv.\n"
+    exit 0
+fi
+
+fail=0
+
+if ! "${RUFF[@]}" check --force-exclude $files > /dev/null 2>&1; then
+    printf "$ERROR_SIGN Ruff lint issues. Run \033[38;5;208mruff check --fix\033[0m. Offenders:\n"
+    "${RUFF[@]}" check --force-exclude $files 2>&1 | sed 's/^/      /'
+    fail=1
+fi
+
+if ! "${RUFF[@]}" format --check --force-exclude $files > /dev/null 2>&1; then
+    printf "$ERROR_SIGN Ruff found unformatted files. Run \033[38;5;208mruff format\033[0m on:\n"
+    "${RUFF[@]}" format --check --force-exclude $files 2>&1 \
+        | grep -iE 'would reformat' | sed 's/^/      /'
+    fail=1
+fi
+
+(( fail )) && exit 1
+printf "$VALID_SIGN Ruff passed\n"

--- a/tests/pre-commit-ruff.test.zsh
+++ b/tests/pre-commit-ruff.test.zsh
@@ -1,0 +1,67 @@
+#!/bin/zsh
+TEST_NAME=`basename "$0"`
+HOOK_CHECK=`echo ${0:a:h}/../templates/hooks/$TEST_NAME | sed 's@\.test@@'`
+
+# The hook only runs when the repo opts into ruff. Give the temp test
+# repo a [tool.ruff] config so the gate passes; default lint select
+# (E4/E7/E9/F) + the formatter are enough to tell the cases apart.
+cat > pyproject.toml <<'EOF'
+[tool.ruff]
+line-length = 100
+EOF
+
+# Resolve ruff the same way the hook does; skip gracefully if none is
+# available (the hook itself warn+skips, so assertions would be moot).
+# Mirrors the npx-availability probe in the prettier test.
+ruff_ok=0
+if [[ -x ".venv/bin/ruff" ]] || type ruff > /dev/null 2>&1; then
+    ruff_ok=1
+elif type uvx > /dev/null 2>&1 && uvx ruff --version > /dev/null 2>&1; then
+    ruff_ok=1
+fi
+(( ! ruff_ok )) && { printf "  ! ruff/uvx unavailable — skipping\n"; exit 0 }
+
+printf "Should pass on a clean, well-formatted file\n"
+TEST_FILE="ok.py"
+printf 'a = 1\n' > $TEST_FILE
+git add $TEST_FILE
+$HOOK_CHECK &> /dev/null || exit 1
+
+printf "Should throw on a badly-formatted file (format --check)\n"
+# `a  =  1` is format-dirty (the formatter rewrites it) but NOT in the
+# default lint select — so this isolates the `ruff format --check` pass,
+# the exact step a `ruff check`-only hook would miss.
+printf 'a  =  1\n' > $TEST_FILE
+git add $TEST_FILE
+$HOOK_CHECK &> /dev/null && exit 1
+
+printf "Should throw on a lint error (check)\n"
+# Unused import -> F401 (in the default select). Format-clean, so this
+# isolates the `ruff check` pass.
+printf 'import os\n' > $TEST_FILE
+git add $TEST_FILE
+$HOOK_CHECK &> /dev/null && exit 1
+
+printf "Should skip when the repo has no ruff config\n"
+git reset -q
+rm -f $TEST_FILE pyproject.toml
+printf 'a  =  1\n' > $TEST_FILE
+git add $TEST_FILE
+# No [tool.ruff] / ruff.toml -> opt-in gate fails -> hook exits 0 even
+# though the file is badly formatted.
+$HOOK_CHECK &> /dev/null || exit 1
+
+printf "Should ignore non-Python files\n"
+git reset -q
+rm -f $TEST_FILE
+cat > pyproject.toml <<'EOF'
+[tool.ruff]
+line-length = 100
+EOF
+TEST_FILE="data.txt"
+printf 'not   python   at all\n' > $TEST_FILE
+git add $TEST_FILE
+# No .py files staged -> hook exits 0 without running ruff.
+$HOOK_CHECK &> /dev/null || exit 1
+
+exit 0


### PR DESCRIPTION
## What

Adds `pre-commit-ruff.zsh` — runs **both** `ruff check` and `ruff format --check` on staged Python files, scoped to repos that opt into ruff (`[tool.ruff]` in `pyproject.toml`, or `ruff.toml`/`.ruff.toml`).

## Why

CI commonly runs lint and format as **two separate steps**, so a clean `ruff check` does **not** imply a clean `ruff format`. Skipping the format check locally is exactly how a format-only failure reaches CI — which is what happened on a recent trade-agents PR (lint job red on `ruff format --check` even though `ruff check` was clean locally). This hook closes that gap so it's caught at commit time.

## Design

Mirrors the existing `pre-commit-prettier.zsh`:
- **Opt-in gate** — only fires when the repo actually uses ruff; otherwise silently skips (never downloads/flags in non-ruff repos).
- **Binary resolution** — project `.venv/bin/ruff` (pinned) → `ruff` on PATH → `uvx ruff` (matches uv-based CI) → warn+skip.
- `--force-exclude` so ruff honours the repo's own exclude config even with explicit staged paths.
- Skippable like any hook via `git -c hook.skip=ruff ...`.

## Tests

`tests/pre-commit-ruff.test.zsh` (full suite green) covers: clean file passes, badly-formatted file fails the **format** pass, lint error fails the **check** pass, no-ruff-config skips, non-Python files ignored. Skips gracefully when no ruff/uvx is resolvable (mirrors the prettier test's availability probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)